### PR TITLE
Add initial gRPC support

### DIFF
--- a/docs/gRPC.md
+++ b/docs/gRPC.md
@@ -1,0 +1,119 @@
+# gRPC Support
+
+## Overview
+
+This project now includes initial gRPC server support alongside the existing REST API.
+
+The current implementation introduces the required infrastructure for gRPC communication while keeping the existing REST endpoints unchanged. A simple `HelloService` is provided as a proof of concept to validate the integration.
+
+## Features
+
+* gRPC server integration
+* Protocol Buffers code generation
+* Maven build integration
+* Java 21 compatible configuration
+* Sample `HelloService`
+* Verified using `grpcurl`
+
+## Project Structure
+
+```text
+src/
+├── main/
+│   ├── java/
+│   │   └── ...grpc...
+│   └── proto/
+│       └── hello.proto
+```
+
+## Configuration
+
+The gRPC server runs independently from the REST server.
+
+Example configuration:
+
+```yaml
+server:
+  port: 8080
+
+grpc:
+  server:
+    port: 9090
+```
+
+## Building
+
+Compile the project normally:
+
+```bash
+./mvnw clean compile
+```
+
+Run the application:
+
+```bash
+./mvnw spring-boot:run
+```
+
+## Testing
+
+List available services:
+
+```bash
+grpcurl -plaintext -proto hello.proto localhost:9090 list
+```
+
+Expected output:
+
+```text
+hello.HelloService
+```
+
+Describe the service:
+
+```bash
+grpcurl -plaintext -proto hello.proto localhost:9090 describe hello.HelloService
+```
+
+Invoke the sample service:
+
+```bash
+grpcurl -plaintext -proto hello.proto -d '{"name":"Pramod"}' localhost:9090 hello.HelloService/SayHello
+```
+
+Expected response:
+
+```json
+{
+  "message": "Hello Pramod from Distributed Rate Limiter"
+}
+```
+
+> **PowerShell users**
+>
+> Depending on your shell, JSON escaping may differ. If the command above fails because of quoting, use:
+>
+> ```powershell
+> grpcurl -plaintext -proto hello.proto -d '{\"name\":\"Pramod\"}' localhost:9090 hello.HelloService/SayHello
+> ```
+
+## Current Status
+
+This is the initial gRPC integration.
+
+The current implementation includes a sample service to verify that:
+
+* Protocol Buffer generation works correctly.
+* The gRPC server starts successfully.
+* Requests and responses are correctly serialized.
+* Clients can communicate with the server using `grpcurl`.
+
+## Future Work
+
+Potential future enhancements include:
+
+* Implementing the existing rate limiting API over gRPC.
+* Server Reflection support.
+* `grpcui` integration.
+* Additional streaming APIs where appropriate.
+* Production-ready gRPC documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -19,9 +19,13 @@
         <jacoco.min.instruction.coverage>0.50</jacoco.min.instruction.coverage>
         <jacoco.min.branch.coverage>0.50</jacoco.min.branch.coverage>
         <maven.project.sourceRoots.warningsDisabled>true</maven.project.sourceRoots.warningsDisabled>
+        <protobuf.version>4.31.1</protobuf.version>
+        <grpc.version>1.63.0</grpc.version>
     </properties>
 
+
     <dependencies>
+
         <!-- Spring Boot Starters -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -43,6 +47,48 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-pool2</artifactId>
         </dependency>
+        <!-- Spring gRPC (Netty Server) -->
+        <dependency>
+            <groupId>net.devh</groupId>
+            <artifactId>grpc-server-spring-boot-starter</artifactId>
+            <version>3.1.0.RELEASE</version>
+        </dependency>
+        <!-- Use shaded Netty -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
         <!-- JSON logging support -->
         <dependency>
             <groupId>net.logstash.logback</groupId>
@@ -264,6 +310,40 @@
                     </jvmArgs>
                 </configuration>
                 <!-- executions removed to prevent automatic execution during CI/CD -->
+            </plugin>
+
+            <plugin>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.7.1</version>
+                <extensions>true</extensions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version>
+
+                <configuration>
+                    <protocArtifact>
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+                    </protocArtifact>
+
+                    <pluginId>grpc-java</pluginId>
+
+                    <pluginArtifact>
+                        io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}
+                    </pluginArtifact>
+                </configuration>
+
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/dev/bnacar/distributedratelimiter/grpc/HelloGrpcService.java
+++ b/src/main/java/dev/bnacar/distributedratelimiter/grpc/HelloGrpcService.java
@@ -1,0 +1,25 @@
+package dev.bnacar.distributedratelimiter.grpc;
+
+import io.grpc.stub.StreamObserver;
+import net.devh.boot.grpc.server.service.GrpcService;
+
+import dev.bnacar.distributedratelimiter.grpc.HelloServiceGrpc;
+import dev.bnacar.distributedratelimiter.grpc.HelloRequest;
+import dev.bnacar.distributedratelimiter.grpc.HelloReply;
+
+@GrpcService
+public class HelloGrpcService extends HelloServiceGrpc.HelloServiceImplBase {
+
+    @Override
+    public void sayHello(
+            HelloRequest request,
+            StreamObserver<HelloReply> responseObserver) {
+
+        HelloReply reply = HelloReply.newBuilder()
+                .setMessage("Hello " + request.getName() + " from Distributed Rate Limiter")
+                .build();
+
+        responseObserver.onNext(reply);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/proto/hello.proto
+++ b/src/main/proto/hello.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package hello;
+
+option java_package = "dev.bnacar.distributedratelimiter.grpc";
+option java_multiple_files = true;
+
+service HelloService {
+  rpc SayHello (HelloRequest) returns (HelloReply);
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -131,3 +131,11 @@ ratelimiter.adaptive.min-capacity=10
 ratelimiter.adaptive.max-capacity=100000
 ratelimiter.adaptive.learning-window-days=30
 ratelimiter.adaptive.min-data-points=1000
+
+
+spring.grpc.server.port=9090
+
+spring.grpc.server.keep-alive.time=2h
+spring.grpc.server.keep-alive.timeout=20s
+spring.grpc.server.keep-alive.permit-time=5m
+spring.grpc.server.keep-alive.permit-without-calls=false


### PR DESCRIPTION
## Summary

This PR introduces the initial gRPC infrastructure for the project while keeping the existing REST API unchanged.

### Changes

- Added gRPC server support
- Added Protocol Buffers configuration
- Configured Maven protobuf code generation
- Added a sample `HelloService` implementation
- Added `hello.proto`
- Added gRPC documentation under `docs/gRPC.md`

### Verification

Verified the implementation by:

- Starting the Spring Boot application successfully
- Confirming the gRPC server is available on port 9090
- Listing services using `grpcurl`
- Invoking `HelloService/SayHello` successfully

### Notes

This is an initial integration intended to establish the gRPC infrastructure.

The sample `HelloService` is provided as a proof of concept. Once the overall approach is reviewed, the existing rate limiter functionality can be exposed through gRPC in a follow-up PR if desired.