### PR TITLE
Fix Snyk container findings

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -132,12 +132,12 @@ curl http://localhost:8080/metrics
 The Dockerfile uses a multi-stage build:
 
 1. **Build Stage**: Uses `eclipse-temurin:21-jdk` to compile the application
-2. **Runtime Stage**: Uses `eclipse-temurin:21-jre` for smaller image size
+2. **Runtime Stage**: Uses a pinned `eclipse-temurin:21-jre-alpine` image for a smaller image and reduced OS-package attack surface
 
 ### Security Features
 
-- Runs as non-root user (`appuser:1000`)
-- Minimal runtime dependencies
+- Runs as non-root user (`appuser:1001`)
+- Minimal Alpine runtime with no additional packages installed
 - Health check integrated
 - Proper signal handling for graceful shutdown
 
@@ -167,7 +167,7 @@ The Dockerfile uses a multi-stage build:
    docker compose logs app
    
    # Manual health check
-   docker compose exec app curl -f http://localhost:8080/actuator/health
+   docker compose exec app wget -qO- http://localhost:8080/actuator/health
    ```
 
 3. **Port conflicts**
@@ -204,7 +204,7 @@ The Dockerfile uses a multi-stage build:
 
 ```bash
 # Interactive debugging
-docker compose exec app bash
+docker compose exec app sh
 
 # View logs
 docker compose logs -f app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Docker build for Distributed Rate Limiter
 # Build stage
-FROM eclipse-temurin:21.0.10_7-jdk AS build
+FROM eclipse-temurin:21.0.11_10-jdk AS build
 
 # Set working directory
 WORKDIR /app
@@ -12,27 +12,17 @@ COPY . .
 RUN chmod +x mvnw && ./mvnw package -DskipTests -B
 
 # Runtime stage
-FROM eclipse-temurin:21.0.10_7-jre AS runtime
+FROM eclipse-temurin:21.0.11_10-jre-alpine-3.23 AS runtime
 
-# Apply current Ubuntu security updates and install curl for health checks.
-RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends curl && \
-    rm -rf /var/lib/apt/lists/*
-
-# Create non-root user for security
-# Use a different UID/GID to avoid conflicts with existing users
-RUN groupadd -g 1001 appuser && \
-    useradd -d /app -g appuser -u 1001 appuser
+# Create a locked-down system user without a home directory or login shell.
+RUN addgroup -S -g 1001 appuser && \
+    adduser -S -D -H -u 1001 -G appuser appuser
 
 # Set working directory
 WORKDIR /app
 
-# Copy the built JAR from build stage
-COPY --from=build /app/target/*.jar app.jar
-
-# Change ownership to non-root user
-RUN chown -R appuser:appuser /app
+# Copy the built JAR with its final ownership, avoiding an extra writable layer.
+COPY --from=build --chown=appuser:appuser /app/target/*.jar app.jar
 
 # Switch to non-root user
 USER appuser
@@ -45,7 +35,7 @@ ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Xmx512m -Xms256m"
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8080/actuator/health || exit 1
+    CMD wget -q --spider http://localhost:8080/actuator/health || exit 1
 
 # Start the application with graceful shutdown
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/actuator/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/examples/web-dashboard/package-lock.json
+++ b/examples/web-dashboard/package-lock.json
@@ -3513,9 +3513,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4784,9 +4784,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/test/java/dev/bnacar/distributedratelimiter/pipeline/DockerImageTest.java
+++ b/src/test/java/dev/bnacar/distributedratelimiter/pipeline/DockerImageTest.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class DockerImageTest {
 
     private static final String TEMURIN_21_BUILD_STAGE = "FROM eclipse-temurin:21";
-    private static final String TEMURIN_21_RUNTIME_STAGE = "FROM eclipse-temurin:21";
-    private static final String PINNED_RUNTIME_IMAGE = "eclipse-temurin:21.0.10_7-jre";
+    private static final String TEMURIN_21_RUNTIME_STAGE = "FROM eclipse-temurin:21.0.11_10-jre-alpine-3.23";
+    private static final String PINNED_RUNTIME_IMAGE = "eclipse-temurin:21.0.11_10-jre-alpine-3.23";
 
     @Test
     @DisplayName("Dockerfile should contain multi-stage build")
@@ -54,6 +54,10 @@ class DockerImageTest {
         
         assertTrue(dockerfileContent.contains("USER appuser"), 
             "Dockerfile should run as non-root user");
+        assertTrue(dockerfileContent.contains("jre-alpine-3.23"),
+            "Dockerfile should use the security-hardened Alpine runtime image");
+        assertFalse(dockerfileContent.contains("apt-get"),
+            "Dockerfile runtime should not install Ubuntu packages");
         assertTrue(dockerfileContent.contains("HEALTHCHECK"), 
             "Dockerfile should include health check");
     }


### PR DESCRIPTION
## Summary

- upgrade the build image to Eclipse Temurin 21.0.11
- replace the Ubuntu runtime with the pinned Temurin 21.0.11 Alpine 3.23 runtime
- remove the runtime `apt` and `curl` package installation
- retain container health checks with BusyBox `wget`
- keep the application locked to the non-root `appuser` account and copy the JAR with its final ownership
- update Docker Compose, tests, and Docker documentation to match

## Why

Snyk reported 85 vulnerabilities inherited from the Ubuntu 24.04 runtime image (1 high, 61 medium, and 23 low). Moving the final image to the current, minimal Alpine runtime removes that vulnerable Ubuntu package set instead of suppressing findings or carrying package-manager remediation layers.

## Impact

The application remains on Java 21 and continues to run as UID/GID 1001. Container and Compose health checks now use BusyBox `wget`; interactive container debugging uses `sh` rather than `bash`.

## Validation

- `git diff --check`
- `docker compose config --quiet`
- focused `DockerImageTest` Maven tests
- full `docker build --pull -t distributed-rate-limiter:snyk-fix .`
- runtime verification for Java 21.0.11, UID/GID 1001, `wget`, image user, health check, and entrypoint
