### PR TITLE
Fix all remaining Snyk container and Kubernetes findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,10 @@ RUN chmod +x mvnw && ./mvnw package -DskipTests -B
 # Runtime stage
 FROM eclipse-temurin:21.0.11_10-jre-alpine-3.23 AS runtime
 
-# Create a locked-down system user without a home directory or login shell.
-RUN addgroup -S -g 1001 appuser && \
-    adduser -S -D -H -u 1001 -G appuser appuser
+# Apply Alpine security fixes, then create a locked-down high-numbered system user.
+RUN apk upgrade --no-cache && \
+    addgroup -S -g 10001 appuser && \
+    adduser -S -D -H -u 10001 -G appuser appuser
 
 # Set working directory
 WORKDIR /app

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.20%
+    patch:
+      default:
+        target: 100%
+        threshold: 0%

--- a/k8s/base/backup-cronjob.yaml
+++ b/k8s/base/backup-cronjob.yaml
@@ -27,8 +27,11 @@ spec:
           serviceAccountName: redis-backup
           securityContext:
             runAsNonRoot: true
-            runAsUser: 1001
-            fsGroup: 1001
+            runAsUser: 10001
+            runAsGroup: 10001
+            fsGroup: 10001
+            seccompProfile:
+              type: RuntimeDefault
           containers:
           - name: backup
             image: ghcr.io/uppnrise/distributed-rate-limiter:backup-tools
@@ -83,6 +86,9 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              runAsUser: 10001
+              runAsGroup: 10001
               capabilities:
                 drop:
                 - ALL

--- a/k8s/base/deployment.yaml
+++ b/k8s/base/deployment.yaml
@@ -34,8 +34,11 @@ spec:
       serviceAccountName: rate-limiter
       securityContext:
         runAsNonRoot: true
-        runAsUser: 1001
-        fsGroup: 1001
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: rate-limiter
         image: ghcr.io/uppnrise/distributed-rate-limiter:latest
@@ -117,6 +120,9 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
           capabilities:
             drop:
             - ALL

--- a/k8s/base/rbac.yaml
+++ b/k8s/base/rbac.yaml
@@ -7,39 +7,3 @@ metadata:
     app.kubernetes.io/name: distributed-rate-limiter
     app.kubernetes.io/component: serviceaccount
 automountServiceAccountToken: false
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: rate-limiter
-  namespace: rate-limiter
-  labels:
-    app.kubernetes.io/name: distributed-rate-limiter
-    app.kubernetes.io/component: rbac
-rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["configmaps"]
-  verbs: ["get", "list"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list"]
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: rate-limiter
-  namespace: rate-limiter
-  labels:
-    app.kubernetes.io/name: distributed-rate-limiter
-    app.kubernetes.io/component: rbac
-subjects:
-- kind: ServiceAccount
-  name: rate-limiter
-  namespace: rate-limiter
-roleRef:
-  kind: Role
-  name: rate-limiter
-  apiGroup: rbac.authorization.k8s.io

--- a/k8s/environments/dev/deployment-patch.yaml
+++ b/k8s/environments/dev/deployment-patch.yaml
@@ -7,8 +7,25 @@ spec:
   replicas: 1
   template:
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: rate-limiter
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          capabilities:
+            drop:
+            - ALL
         env:
         - name: SPRING_PROFILES_ACTIVE
           value: "dev"

--- a/k8s/environments/prod/deployment-patch.yaml
+++ b/k8s/environments/prod/deployment-patch.yaml
@@ -12,8 +12,25 @@ spec:
         prometheus.io/port: "8080"
         prometheus.io/path: "/actuator/prometheus"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: rate-limiter
+        imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
+          capabilities:
+            drop:
+            - ALL
         env:
         - name: SPRING_PROFILES_ACTIVE
           value: "production"

--- a/src/test/java/dev/bnacar/distributedratelimiter/adaptive/UserBehaviorModelerTest.java
+++ b/src/test/java/dev/bnacar/distributedratelimiter/adaptive/UserBehaviorModelerTest.java
@@ -47,12 +47,14 @@ class UserBehaviorModelerTest {
     }
 
     @Test
-    void testBurstinessCalculation() {
+    void testBurstinessCalculation() throws InterruptedException {
         // Arrange
         String key = "test:key";
 
         // Record requests with varying intervals to create burstiness
-        for (int i = 0; i < 20; i++) {
+        modeler.recordRequest(key, 1, true);
+        Thread.sleep(2);
+        for (int i = 1; i < 20; i++) {
             modeler.recordRequest(key, 1, true);
         }
 
@@ -61,7 +63,7 @@ class UserBehaviorModelerTest {
 
         // Assert
         assertNotNull(behavior);
-        assertTrue(behavior.getBurstiness() >= 0);
+        assertTrue(behavior.getBurstiness() > 0);
     }
 
     @Test

--- a/src/test/java/dev/bnacar/distributedratelimiter/deployment/DeploymentTemplateValidationTest.java
+++ b/src/test/java/dev/bnacar/distributedratelimiter/deployment/DeploymentTemplateValidationTest.java
@@ -203,7 +203,11 @@ class DeploymentTemplateValidationTest {
         // Check security context
         Map<String, Object> securityContext = (Map<String, Object>) podSpec.get("securityContext");
         assertThat(securityContext.get("runAsNonRoot")).isEqualTo(true);
-        assertThat(securityContext.get("runAsUser")).isEqualTo(1001);
+        assertThat(securityContext.get("runAsUser")).isEqualTo(10001);
+        assertThat(securityContext.get("runAsGroup")).isEqualTo(10001);
+        assertThat(securityContext.get("fsGroup")).isEqualTo(10001);
+        assertThat((Map<String, Object>) securityContext.get("seccompProfile"))
+            .containsEntry("type", "RuntimeDefault");
         
         // Check containers
         List<Map<String, Object>> containers = (List<Map<String, Object>>) podSpec.get("containers");
@@ -212,6 +216,18 @@ class DeploymentTemplateValidationTest {
         Map<String, Object> container = containers.get(0);
         assertThat(container.get("name")).isEqualTo("rate-limiter");
         assertThat(container.get("image")).isEqualTo("ghcr.io/uppnrise/distributed-rate-limiter:latest");
+        assertThat(container.get("imagePullPolicy")).isEqualTo("Always");
+
+        Map<String, Object> containerSecurityContext =
+            (Map<String, Object>) container.get("securityContext");
+        assertThat(containerSecurityContext)
+            .containsEntry("allowPrivilegeEscalation", false)
+            .containsEntry("readOnlyRootFilesystem", true)
+            .containsEntry("runAsNonRoot", true)
+            .containsEntry("runAsUser", 10001)
+            .containsEntry("runAsGroup", 10001);
+        assertThat((List<String>) ((Map<String, Object>) containerSecurityContext
+            .get("capabilities")).get("drop")).containsExactly("ALL");
         
         // Check resource limits
         Map<String, Object> resources = (Map<String, Object>) container.get("resources");
@@ -223,6 +239,105 @@ class DeploymentTemplateValidationTest {
         // Check volume mounts
         List<Map<String, Object>> volumeMounts = (List<Map<String, Object>>) container.get("volumeMounts");
         assertThat(volumeMounts).isNotEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testEnvironmentDeploymentPatchesRepeatRequiredSecurityControls() throws IOException {
+        for (String environment : List.of("dev", "prod")) {
+            Path patchPath = Paths.get(K8S_ENVIRONMENTS_PATH, environment,
+                "deployment-patch.yaml");
+            Map<String, Object> patch = loadSingleYamlDocument(patchPath);
+            Map<String, Object> spec = mapAt(patch, "spec");
+            Map<String, Object> template = mapAt(spec, "template");
+            Map<String, Object> podSpec = mapAt(template, "spec");
+            Map<String, Object> podSecurityContext = mapAt(podSpec, "securityContext");
+
+            assertThat(podSecurityContext)
+                .as("%s pod security context", environment)
+                .containsEntry("runAsNonRoot", true)
+                .containsEntry("runAsUser", 10001)
+                .containsEntry("runAsGroup", 10001)
+                .containsEntry("fsGroup", 10001);
+            assertThat(mapAt(podSecurityContext, "seccompProfile"))
+                .containsEntry("type", "RuntimeDefault");
+
+            List<Map<String, Object>> containers = listAt(podSpec, "containers");
+            Map<String, Object> container = containers.get(0);
+            assertThat(container.get("imagePullPolicy")).isEqualTo("Always");
+
+            Map<String, Object> containerSecurityContext = mapAt(container, "securityContext");
+            assertThat(containerSecurityContext)
+                .containsEntry("allowPrivilegeEscalation", false)
+                .containsEntry("readOnlyRootFilesystem", true)
+                .containsEntry("runAsNonRoot", true)
+                .containsEntry("runAsUser", 10001)
+                .containsEntry("runAsGroup", 10001);
+            assertThat((List<String>) mapAt(containerSecurityContext, "capabilities")
+                .get("drop")).containsExactly("ALL");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testApplicationServiceAccountHasNoUnusedRbacPermissions() throws IOException {
+        Yaml yaml = new Yaml();
+        List<Map<String, Object>> manifests = new java.util.ArrayList<>();
+        for (Object document : yaml.loadAll(Files.readString(
+            Paths.get(K8S_BASE_PATH, "rbac.yaml")))) {
+            manifests.add((Map<String, Object>) document);
+        }
+
+        assertThat(manifests).hasSize(1);
+        assertThat(manifests.get(0).get("kind")).isEqualTo("ServiceAccount");
+        assertThat(manifests.get(0).get("automountServiceAccountToken")).isEqualTo(false);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testBackupCronJobUsesNonHostUid() throws IOException {
+        Yaml yaml = new Yaml();
+        Map<String, Object> cronJob = null;
+        for (Object document : yaml.loadAll(Files.readString(
+            Paths.get(K8S_BASE_PATH, "backup-cronjob.yaml")))) {
+            Map<String, Object> manifest = (Map<String, Object>) document;
+            if ("CronJob".equals(manifest.get("kind"))) {
+                cronJob = manifest;
+                break;
+            }
+        }
+
+        assertThat(cronJob).isNotNull();
+        Map<String, Object> jobTemplate = mapAt(mapAt(cronJob, "spec"), "jobTemplate");
+        Map<String, Object> jobSpec = mapAt(jobTemplate, "spec");
+        Map<String, Object> template = mapAt(jobSpec, "template");
+        Map<String, Object> podSpec = mapAt(template, "spec");
+        assertThat(mapAt(podSpec, "securityContext"))
+            .containsEntry("runAsNonRoot", true)
+            .containsEntry("runAsUser", 10001)
+            .containsEntry("runAsGroup", 10001)
+            .containsEntry("fsGroup", 10001);
+
+        Map<String, Object> container = listAt(podSpec, "containers").get(0);
+        assertThat(mapAt(container, "securityContext"))
+            .containsEntry("runAsNonRoot", true)
+            .containsEntry("runAsUser", 10001)
+            .containsEntry("runAsGroup", 10001);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadSingleYamlDocument(Path path) throws IOException {
+        return (Map<String, Object>) new Yaml().load(Files.readString(path));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> mapAt(Map<String, Object> parent, String key) {
+        return (Map<String, Object>) parent.get(key);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Map<String, Object>> listAt(Map<String, Object> parent, String key) {
+        return (List<Map<String, Object>>) parent.get(key);
     }
     
     @Test

--- a/src/test/java/dev/bnacar/distributedratelimiter/pipeline/DockerImageTest.java
+++ b/src/test/java/dev/bnacar/distributedratelimiter/pipeline/DockerImageTest.java
@@ -56,6 +56,8 @@ class DockerImageTest {
             "Dockerfile should run as non-root user");
         assertTrue(dockerfileContent.contains("jre-alpine-3.23"),
             "Dockerfile should use the security-hardened Alpine runtime image");
+        assertTrue(dockerfileContent.contains("apk upgrade --no-cache"),
+            "Dockerfile should install all available Alpine security upgrades");
         assertFalse(dockerfileContent.contains("apt-get"),
             "Dockerfile runtime should not install Ubuntu packages");
         assertTrue(dockerfileContent.contains("HEALTHCHECK"), 


### PR DESCRIPTION
## Summary

Fix all currently open findings across the requested Snyk container and Kubernetes projects.

### Container

- upgrade Alpine runtime packages during the image build
- update `libexpat` from `2.8.1-r0` to `2.8.2-r0`
- update `p11-kit` and `p11-kit-trust` from `0.25.5-r2` to `0.26.2-r0`
- move the application runtime identity from UID/GID 1001 to 10001

### Kubernetes

- apply UID/GID 10001, `runAsNonRoot`, `RuntimeDefault` seccomp, read-only root filesystems, disabled privilege escalation, and dropped capabilities
- repeat required security controls in both dev and production overlays because Snyk scans those patch files independently
- explicitly set `imagePullPolicy: Always` in both overlays
- harden the backup CronJob with the same high-numbered identity and container controls
- remove the unused application Role and RoleBinding, including unnecessary access to Secrets; the ServiceAccount already disables token automount

## Snyk scope

- Dockerfile: 14 fixable OS findings
- dev deployment patch: 6 cloud configuration findings
- prod deployment patch: 6 cloud configuration findings
- base RBAC: 1 dangerous-permissions finding
- base deployment: 1 host-UID collision finding
- backup CronJob: 1 host-UID collision finding
- Redis manifest: already reported 0 findings

## Root cause

The runtime base image snapshot predated security-fixed Alpine packages available in the configured repositories. Kubernetes base manifests used UID 1001, the environment patches did not repeat controls required by standalone file scanning, and the application ServiceAccount retained RBAC permissions the application does not use.

## Impact

The application remains on Java 21.0.11, but the final image contains the fixed Alpine packages and runs as UID/GID 10001. Kubernetes workloads now satisfy the requested least-privilege controls without granting the application Kubernetes API access.

## Validation

- `./mvnw -Dtest=DockerImageTest,DeploymentTemplateValidationTest test`: 23 tests passed, 1 conditional test skipped
- `./mvnw test`: 522 tests passed, 2 conditional tests skipped
- `docker build --pull -t distributed-rate-limiter:snyk-all-fixes .`: passed
- runtime verification: Java 21.0.11; UID/GID 10001; `libexpat 2.8.2-r0`; `p11-kit 0.26.2-r0`
- YAML parsing and security assertions cover every changed manifest
- `git diff --check`: passed

The repository's existing Kustomize generator configuration still prevents complete overlay rendering because `behavior: merge` cannot find an in-scope resource ID; this predates and is independent of this PR.
