### PR TITLE
Fix current Snyk container and Redis findings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,21 +12,16 @@ COPY . .
 RUN chmod +x mvnw && ./mvnw package -DskipTests -B
 
 # Runtime stage
-FROM eclipse-temurin:21.0.11_10-jre-alpine-3.23 AS runtime
-
-# Apply Alpine security fixes, then create a locked-down high-numbered system user.
-RUN apk upgrade --no-cache && \
-    addgroup -S -g 10001 appuser && \
-    adduser -S -D -H -u 10001 -G appuser appuser
+FROM eclipse-temurin:21.0.11_10-jre-ubi10-minimal AS runtime
 
 # Set working directory
 WORKDIR /app
 
 # Copy the built JAR with its final ownership, avoiding an extra writable layer.
-COPY --from=build --chown=appuser:appuser /app/target/*.jar app.jar
+COPY --from=build --chown=10001:0 /app/target/*.jar app.jar
 
 # Switch to non-root user
-USER appuser
+USER 10001
 
 # Expose port
 EXPOSE 8080
@@ -36,7 +31,7 @@ ENV JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Xmx512m -Xms256m"
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD wget -q --spider http://localhost:8080/actuator/health || exit 1
+    CMD curl --fail --silent --show-error http://localhost:8080/actuator/health > /dev/null || exit 1
 
 # Start the application with graceful shutdown
 ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"]

--- a/k8s/base/redis.yaml
+++ b/k8s/base/redis.yaml
@@ -26,11 +26,13 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 999
-        fsGroup: 999
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
       containers:
       - name: redis
         image: redis:7.4-alpine
+        imagePullPolicy: Always
         ports:
         - containerPort: 6379
           name: redis
@@ -94,12 +96,16 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
           capabilities:
             drop:
             - ALL
       # Redis Exporter for Prometheus monitoring
       - name: redis-exporter
         image: oliver006/redis_exporter:v1.66.0
+        imagePullPolicy: Always
         ports:
         - containerPort: 9121
           name: metrics
@@ -119,9 +125,20 @@ spec:
           limits:
             memory: "128Mi"
             cpu: "100m"
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: metrics
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 3
+          failureThreshold: 3
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10001
+          runAsGroup: 10001
           capabilities:
             drop:
             - ALL

--- a/src/test/java/dev/bnacar/distributedratelimiter/deployment/DeploymentTemplateValidationTest.java
+++ b/src/test/java/dev/bnacar/distributedratelimiter/deployment/DeploymentTemplateValidationTest.java
@@ -390,6 +390,11 @@ class DeploymentTemplateValidationTest {
         
         Map<String, Object> template = (Map<String, Object>) spec.get("template");
         Map<String, Object> podSpec = (Map<String, Object>) template.get("spec");
+
+        Map<String, Object> podSecurityContext =
+            (Map<String, Object>) podSpec.get("securityContext");
+        assertThat(podSecurityContext.get("runAsUser")).isEqualTo(10001);
+        assertThat(podSecurityContext.get("fsGroup")).isEqualTo(10001);
         
         // Check containers (should have redis + redis-exporter)
         List<Map<String, Object>> containers = (List<Map<String, Object>>) podSpec.get("containers");
@@ -402,6 +407,9 @@ class DeploymentTemplateValidationTest {
             .orElse(null);
         assertThat(redisContainer).isNotNull();
         assertThat(redisContainer.get("image")).asString().contains("redis:");
+        assertThat(redisContainer.get("imagePullPolicy")).isEqualTo("Always");
+        assertThat((Map<String, Object>) redisContainer.get("securityContext"))
+            .containsEntry("runAsUser", 10001);
         
         // Check redis-exporter container
         Map<String, Object> exporterContainer = containers.stream()
@@ -410,6 +418,10 @@ class DeploymentTemplateValidationTest {
             .orElse(null);
         assertThat(exporterContainer).isNotNull();
         assertThat(exporterContainer.get("image")).asString().contains("redis_exporter:");
+        assertThat(exporterContainer.get("imagePullPolicy")).isEqualTo("Always");
+        assertThat(exporterContainer).containsKey("livenessProbe");
+        assertThat((Map<String, Object>) exporterContainer.get("securityContext"))
+            .containsEntry("runAsUser", 10001);
     }
     
     @Test

--- a/src/test/java/dev/bnacar/distributedratelimiter/pipeline/DockerImageTest.java
+++ b/src/test/java/dev/bnacar/distributedratelimiter/pipeline/DockerImageTest.java
@@ -28,8 +28,8 @@ import static org.junit.jupiter.api.Assertions.*;
 class DockerImageTest {
 
     private static final String TEMURIN_21_BUILD_STAGE = "FROM eclipse-temurin:21";
-    private static final String TEMURIN_21_RUNTIME_STAGE = "FROM eclipse-temurin:21.0.11_10-jre-alpine-3.23";
-    private static final String PINNED_RUNTIME_IMAGE = "eclipse-temurin:21.0.11_10-jre-alpine-3.23";
+    private static final String TEMURIN_21_RUNTIME_STAGE = "FROM eclipse-temurin:21.0.11_10-jre-ubi10-minimal";
+    private static final String PINNED_RUNTIME_IMAGE = "eclipse-temurin:21.0.11_10-jre-ubi10-minimal";
 
     @Test
     @DisplayName("Dockerfile should contain multi-stage build")
@@ -52,12 +52,12 @@ class DockerImageTest {
         Path dockerfilePath = Paths.get("Dockerfile");
         String dockerfileContent = Files.readString(dockerfilePath);
         
-        assertTrue(dockerfileContent.contains("USER appuser"), 
+        assertTrue(dockerfileContent.contains("USER 10001"),
             "Dockerfile should run as non-root user");
-        assertTrue(dockerfileContent.contains("jre-alpine-3.23"),
-            "Dockerfile should use the security-hardened Alpine runtime image");
-        assertTrue(dockerfileContent.contains("apk upgrade --no-cache"),
-            "Dockerfile should install all available Alpine security upgrades");
+        assertTrue(dockerfileContent.contains("jre-ubi10-minimal"),
+            "Dockerfile should use the vulnerability-free UBI 10 minimal runtime image");
+        assertFalse(dockerfileContent.contains("jre-alpine"),
+            "Dockerfile should not use the vulnerable Alpine runtime image");
         assertFalse(dockerfileContent.contains("apt-get"),
             "Dockerfile runtime should not install Ubuntu packages");
         assertTrue(dockerfileContent.contains("HEALTHCHECK"), 


### PR DESCRIPTION
## What changed

- replace the vulnerable Alpine JRE runtime with the pinned Eclipse Temurin UBI 10 minimal image
- keep the runtime non-root at UID 10001 and update the health check for the UBI tooling
- harden both Redis containers with high-numbered UIDs and `imagePullPolicy: Always`
- add the missing Redis exporter liveness probe
- add regression coverage for both Snyk projects

## Why

The current Snyk retest still reports 14 fixable Alpine package vulnerabilities in the Dockerfile project (`p11-kit` and `expat`) and five Kubernetes configuration findings in `k8s/base/redis.yaml`. The Alpine base itself carries the package backlog, so switching to the official UBI 10 minimal variant removes the vulnerable packages instead of suppressing them.

## Impact

The application continues to use Java 21 and runs as a non-root user. The runtime image is larger than Alpine, but its package scan is clean. Redis and its exporter now always refresh their tagged images, use non-host-overlapping UIDs, and expose liveness coverage.

## Validation

- `./mvnw -Dtest=DockerImageTest,DeploymentTemplateValidationTest test`
- `./mvnw verify`
- built `distributed-rate-limiter:snyk-fix` successfully
- verified image user `10001` and the runtime health-check command
- Docker Scout: 0 critical, 0 high, 0 medium, 0 low vulnerabilities across 313 indexed packages
