### PR TITLE
ci: publish semver Docker tags on release tag pushes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,6 +3,7 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main, develop ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
@@ -375,7 +376,9 @@ jobs:
     name: Build & Push Docker Image
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.event_name == 'workflow_dispatch' && inputs.build_and_push
+    if: >-
+      (github.event_name == 'workflow_dispatch' && inputs.build_and_push) ||
+      (github.event_name == 'push' && github.ref_type == 'tag')
     
     permissions:
       contents: read
@@ -406,6 +409,8 @@ jobs:
           type=ref,event=pr
           type=sha,prefix={{branch}}-
           type=raw,value=latest,enable={{is_default_branch}}
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
           
     - name: Build and push Docker image
       id: build


### PR DESCRIPTION
## Summary

While manually publishing the `v1.4.0` Docker image, discovered that the
"Build & Push Docker Image" job only runs on manual `workflow_dispatch` and
tags images by branch name/SHA - it has never produced a real semantic
version tag (e.g. `ghcr.io/uppnrise/distributed-rate-limiter:1.4.0`),
despite the README, `build-release.sh`, and `prepare-github-release.sh` all
referencing versioned image tags in `docker run` examples. No prior release
(including `v1.3.2`) actually had a versioned tag published to GHCR.

## Changes

- Trigger the workflow on pushes of `v*` tags, in addition to the existing
  `main`/`develop` branch push and PR triggers.
- Run `build-and-push` automatically when the push event is a tag push
  (`github.ref_type == 'tag'`), alongside the existing manual
  `workflow_dispatch` path (unchanged).
- Add `type=semver,pattern={{version}}` and
  `type=semver,pattern={{major}}.{{minor}}` to the `docker/metadata-action`
  tag list. Pushing tag `v1.4.0` will publish
  `ghcr.io/uppnrise/distributed-rate-limiter:1.4.0` and `:1.4`, with
  `:latest` auto-updated for the highest semver tag
  (metadata-action's default `flavor.latest=auto` behavior).

## Why this matters

Future release tags will automatically get a proper multi-arch
(`linux/amd64`, `linux/arm64`) versioned image built on GitHub-hosted
runners - avoiding the local QEMU emulation bug hit when building
`linux/amd64` on Apple Silicon (confirmed independently of this repo's
Dockerfile: even a bare `tar -xzf` fails under `--platform linux/amd64`
emulation on the current Docker Desktop version used here).

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-cd.yml'))"` - YAML parses successfully.
- No changes to existing job logic for branch pushes, PRs, or other
  `workflow_dispatch` inputs - `test`, `static-analysis`, `security-scan`,
  `load-test`, and `quality-gate` jobs are unaffected.
