### PR TITLE
ci: disable branch-prefixed sha tag on tag push events

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -407,7 +407,7 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=pr
-          type=sha,prefix={{branch}}-
+          type=sha,prefix={{branch}}-,enable=${{ github.ref_type == 'branch' }}
           type=raw,value=latest,enable={{is_default_branch}}
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
Fixes a bug in #116: the `type=sha,prefix={{branch}}-` docker/metadata-action rule produces an invalid tag (e.g. `-9630782`) on tag-push events since `{{branch}}` is empty outside branch context, which broke the `v1.4.0` tag-triggered Docker build. Scopes that rule to `enable=${{ github.ref_type == 'branch' }}` so it only applies to branch push/dispatch events.